### PR TITLE
Implement automatic sdk version detection

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,9 +10,9 @@ inputs:
     required: true
 
   sdk-version:
-    description: Zephyr SDK version to use
+    description: Zephyr SDK version to use or "auto" to detect automatically
     required: false
-    default: 0.16.4
+    default: auto
 
   sdk-base:
     description: Base URL of the Zephyr SDK
@@ -88,7 +88,25 @@ runs:
           setup_opt="//"
         fi
 
-        echo "SDK_FILE=zephyr-sdk-${{ inputs.sdk-version }}_${sdk_variant}_minimal.${sdk_ext}" >> $GITHUB_ENV
+        if [ "${{ inputs.sdk-version }}" = "auto" ]; then
+          zephyr_path="zephyr"
+          if west list -f '{abspath}' zephyr; then
+            zephyr_path="$( west list -f '{abspath}' zephyr )"
+          fi
+
+          if [ -f "${zephyr_path}/SDK_VERSION" ]; then
+            echo "Reading SDK version from ${zephyr_path}/SDK_VERSION"
+            sdk_version=$( cat ${zephyr_path}/SDK_VERSION )
+          else
+            echo "Cannot find ${zephyr_path}/SDK_VERSION"
+            exit 1
+          fi
+        else
+          sdk_version="${{ inputs.sdk-version }}"
+        fi
+
+        echo "SDK_VERSION=${sdk_version}" >> $GITHUB_ENV
+        echo "SDK_FILE=zephyr-sdk-${sdk_version}_${sdk_variant}_minimal.${sdk_ext}" >> $GITHUB_ENV
         echo "PIP_CACHE_PATH=${pip_cache_path}" >> $GITHUB_ENV
         echo "SETUP_FILE=${setup_file}" >> $GITHUB_ENV
         echo "SETUP_OPT=${setup_opt}" >> $GITHUB_ENV
@@ -115,10 +133,10 @@ runs:
       name: Download Zephyr SDK
       shell: bash
       run: |
-        wget --progress=dot:giga ${{ inputs.sdk-base }}/v${{ inputs.sdk-version }}/$SDK_FILE
+        wget --progress=dot:giga ${{ inputs.sdk-base }}/v${SDK_VERSION}/${SDK_FILE}
         if [ "${{ runner.os }}" = "Windows" ]; then
           7z x $SDK_FILE
-          mv zephyr-sdk-${{ inputs.sdk-version }} zephyr-sdk
+          mv zephyr-sdk-${SDK_VERSION} zephyr-sdk
         else
           mkdir zephyr-sdk
           tar xvf $SDK_FILE -C zephyr-sdk --strip-components=1

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,31 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Install dependencies
+      shell: bash
+      run: |
+        pip3 install -U pip wheel
+        pip3 install west
+        if [ "${{ runner.os }}" = "Linux" ]; then
+          sudo apt-get update
+          sudo apt-get install ninja-build ccache
+          if [ "${{ runner.arch }}" = "X64" ]; then
+            sudo apt-get install libc6-dev-i386
+          fi
+        elif [ "${{ runner.os }}" = "macOS" ]; then
+          brew install ninja ccache
+        elif [ "${{ runner.os }}" = "Windows" ]; then
+          choco feature enable -n allowGlobalConfirmation
+          choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'
+          choco install ninja wget 7zip
+        fi
+
+    - name: Initialize
+      shell: bash
+      run: |
+        west init -l ${{ inputs.app-path }}
+        west update -o=--depth=1 -n
+
     - name: Environment setup
       id: env-setup
       shell: bash
@@ -68,24 +93,16 @@ runs:
         echo "SETUP_FILE=${setup_file}" >> $GITHUB_ENV
         echo "SETUP_OPT=${setup_opt}" >> $GITHUB_ENV
 
-    - name: Install dependencies
+    - name: Cache Python packages
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.PIP_CACHE_PATH }}
+        key: pip-${{ runner.os }}-${{ hashFiles('zephyr/scripts/requirements*.txt') }}
+
+    - name: Install Python packages
       shell: bash
       run: |
-        pip3 install -U pip wheel
-        pip3 install west
-        if [ "${{ runner.os }}" = "Linux" ]; then
-          sudo apt-get update
-          sudo apt-get install ninja-build ccache
-          if [ "${{ runner.arch }}" = "X64" ]; then
-            sudo apt-get install libc6-dev-i386
-          fi
-        elif [ "${{ runner.os }}" = "macOS" ]; then
-          brew install ninja ccache
-        elif [ "${{ runner.os }}" = "Windows" ]; then
-          choco feature enable -n allowGlobalConfirmation
-          choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'
-          choco install ninja wget 7zip
-        fi
+        pip3 install -r zephyr/scripts/requirements.txt
 
     - name: Cache Zephyr SDK
       id: cache-toolchain
@@ -120,20 +137,3 @@ runs:
             ${SETUP_FILE} ${SETUP_OPT}h
         fi
         ${SETUP_FILE} ${SETUP_OPT}c
-
-    - name: Initialize
-      shell: bash
-      run: |
-        west init -l ${{ inputs.app-path }}
-        west update -o=--depth=1 -n
-
-    - name: Cache Python packages
-      uses: actions/cache@v3
-      with:
-        path: ${{ env.PIP_CACHE_PATH }}
-        key: pip-${{ runner.os }}-${{ hashFiles('zephyr/scripts/requirements*.txt') }}
-
-    - name: Install Python packages
-      shell: bash
-      run: |
-        pip3 install -r zephyr/scripts/requirements.txt


### PR DESCRIPTION
Tested on

- https://github.com/zephyrproject-rtos/example-application/pull/49
- https://github.com/zephyrproject-rtos/zephyr/pull/64802

---

Implement automatic SDK detection based on the SDK_VERSION file in the upstream Zephyr repository. Lookup is in the "zephyr" module directory if available, "zephyr" directory if not.

Switch the default SDK to "auto" so that the workflow will automatically pick the current one for the Zephyr checkout specified in the manifest file.