### PR TITLE
Add qemu and dtc to macOS brew setup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ runs:
             sudo apt-get install libc6-dev-i386
           fi
         elif [ "${{ runner.os }}" = "macOS" ]; then
-          brew install ninja ccache
+          brew install ninja ccache qemu dtc
         elif [ "${{ runner.os }}" = "Windows" ]; then
           choco feature enable -n allowGlobalConfirmation
           choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'


### PR DESCRIPTION
Looks like the current macos-13 and macos-14 GitHub images to not have these two pre-installed. Add them explicitly so we can run qemu tests on those runners.