### PR TITLE
Fix pip update on Windows (and update cache action version)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,8 +30,13 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
+        if [ "${{ runner.os }}" = "Windows" ]; then
+          python.exe -m pip install -U pip
+        fi
+
         pip3 install -U pip wheel
         pip3 install west
+
         if [ "${{ runner.os }}" = "Linux" ]; then
           sudo apt-get update
           sudo apt-get install ninja-build ccache

--- a/action.yml
+++ b/action.yml
@@ -112,7 +112,7 @@ runs:
         echo "SETUP_OPT=${setup_opt}" >> $GITHUB_ENV
 
     - name: Cache Python packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.PIP_CACHE_PATH }}
         key: pip-${{ runner.os }}-${{ hashFiles('zephyr/scripts/requirements*.txt') }}
@@ -124,7 +124,7 @@ runs:
 
     - name: Cache Zephyr SDK
       id: cache-toolchain
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: zephyr-sdk
         key: ${{ env.SDK_FILE }}-${{ inputs.toolchains }}


### PR DESCRIPTION
Looks like windows is a bit particular on how to install pip updates, guess the binary can't overwrite itself or something, tested on https://github.com/zephyrproject-rtos/example-application/pull/51 and https://github.com/zephyrproject-rtos/example-application/pull/51, I'd cut v1.0.1 and update the v1 tag after that, this is currently failing CI upstream which is fairly annoying.

---

Fix pip update on Windows and update cache action version.