### PR TITLE
action: Update actions/cache to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -112,7 +112,7 @@ runs:
         echo "SETUP_OPT=${setup_opt}" >> $GITHUB_ENV
 
     - name: Cache Python packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.PIP_CACHE_PATH }}
         key: pip-${{ runner.os }}-${{ hashFiles('zephyr/scripts/requirements*.txt') }}


### PR DESCRIPTION
actions/cache@v3 is deprecated and we must switch to v4.

Otherwise, you get the following warning:

    Node.js 16 actions are deprecated. Please update the following
    actions to use Node.js 20: actions/cache@v3. For more information
    see:
    https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.