### PR TITLE
windows: do not install packages already present in runner image

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-12, macos-14, windows-2022]
+        os: [ubuntu-22.04, macos-13, macos-14, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/action.yml
+++ b/action.yml
@@ -62,8 +62,7 @@ runs:
           brew install ninja ccache qemu dtc
         elif [ "${{ runner.os }}" = "Windows" ]; then
           choco feature enable -n allowGlobalConfirmation
-          choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'
-          choco install ninja wget 7zip
+          choco install ninja wget
         fi
 
     - name: Initialize


### PR DESCRIPTION
windows-2022 already contains both 7zip and cmake (the later being installed with the same install args we want) so drop them to avoid potential conflicts.