### PR TITLE
workflow: set --runtime-artifact-cleanup

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,4 +47,4 @@ jobs:
           elif [ "${{ runner.os }}" = "Windows" ]; then
             EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O/tmp/twister-out"
           fi
-          ./scripts/twister --force-color --inline-logs -T samples/hello_world -v $EXTRA_TWISTER_FLAGS
+          ./scripts/twister --runtime-artifact-cleanup --force-color --inline-logs -T samples/hello_world -v $EXTRA_TWISTER_FLAGS


### PR DESCRIPTION
Set --runtime-artifact-cleanup on the twister run to reduce the disk usage of the workflow.