### PR TITLE
Added modules input to improve workspace initialization run time

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,15 @@ the necessary modules for a West based [Zephyr workspace application][1].
     manifest-file-name: custom_west.yml
 ```
 
+## Initialize a workspace with only selected modules
+
+```yaml
+- name: Setup Zephyr project
+  uses: zephyrproject-rtos/action-zephyr-setup@v1
+  with:
+    app-path: app
+    toolchains: arm-zephyr-eabi
+    modules: cmsis fatfs hal_adi
+```
+
 [1]: https://docs.zephyrproject.org/latest/develop/application/index.html#zephyr-workspace-app

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,13 @@ inputs:
     required: false
     default: west.yml
 
+  modules:
+    description: |
+      List of modules to limit workspace initialization to, space separated.
+      Defaults to cloning all modules.
+    required: false
+    default:
+
   sdk-version:
     description: Zephyr SDK version to use or "auto" to detect automatically
     required: false
@@ -49,7 +56,6 @@ runs:
           python.exe -m pip install -U pip
         fi
 
-        pip3 install -U pip wheel
         pip3 install west
 
         if [ "${{ runner.os }}" = "Linux" ]; then
@@ -70,7 +76,7 @@ runs:
       shell: bash
       run: |
         west init -l ${{ inputs.app-path }} --mf ${{ inputs.manifest-file-name }}
-        west update -o=--depth=1 -n
+        west update -o=--depth=1 -n ${{ inputs.modules }}
 
     - name: Environment setup
       working-directory: ${{ inputs.base-path }}


### PR DESCRIPTION
## Description

I noticed that `west update [PROJECT ...]` may run for a shorter duration of time if one were to specify a minimum set of Zephyr modules. An action input to select modules could benefit shorter run times for workflows.

## Example

 ```yaml
- name: Setup Zephyr project
  uses: zephyrproject-rtos/action-zephyr-setup@v1
  with:
    app-path: app
    toolchains: arm-zephyr-eabi
    modules: cmsis fatfs hal_adi
```