### PR TITLE
packages: install gperf, needed for userspace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,15 +54,15 @@ runs:
 
         if [ "${{ runner.os }}" = "Linux" ]; then
           sudo apt-get update -y
-          sudo apt-get install -y ninja-build ccache g++-multilib
+          sudo apt-get install -y ninja-build ccache g++-multilib gperf
           if [ "${{ runner.arch }}" = "X64" ]; then
             sudo apt-get install -y libc6-dev-i386
           fi
         elif [ "${{ runner.os }}" = "macOS" ]; then
-          brew install ninja ccache qemu dtc
+          brew install ninja ccache qemu dtc gperf
         elif [ "${{ runner.os }}" = "Windows" ]; then
           choco feature enable -n allowGlobalConfirmation
-          choco install ninja wget
+          choco install ninja wget gperf
         fi
 
     - name: Initialize


### PR DESCRIPTION
gperf is need for building anything supporting userspace.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
