### PR TITLE
west: call init before calling config

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,8 @@ jobs:
         with:
           app-path: zephyr
           toolchains: all
+          west-group-filter: -tools,-bootloader,-babblesim
+          west-project-filter: -nrf_hw_models
 
       - name: Build firmware
         working-directory: zephyr

--- a/action.yml
+++ b/action.yml
@@ -79,13 +79,13 @@ runs:
       working-directory: ${{ inputs.base-path }}
       shell: bash
       run: |
+        west init -l ${{ inputs.app-path }} --mf ${{ inputs.manifest-file-name }}
         if [ -n "${{ inputs.west-group-filter }}" ]; then
           west config manifest.group-filter -- ${{ inputs.west-group-filter }}
         fi
         if [ -n "${{ inputs.west-project-filter }}" ]; then
           west config manifest.project-filter -- ${{ inputs.west-project-filter }}
         fi
-        west init -l ${{ inputs.app-path }} --mf ${{ inputs.manifest-file-name }}
         west update -o=--depth=1 -n
 
     - name: Environment setup


### PR DESCRIPTION
Call init before we configure the workspace.
Also test west filtering in the CI workflow.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
