### PR TITLE
Include actions/setup-python in README samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,12 @@ the necessary modules for a West based [Zephyr workspace application][1].
 
 ```yaml
 - name: Checkout
-  uses: actions/checkout@v3
+  uses: actions/checkout@v4
+
+- name: Set up Python
+  uses: actions/setup-python@v5
+  with:
+    python-version: 3.12
 
 - name: Setup Zephyr project
   uses: zephyrproject-rtos/action-zephyr-setup@v1
@@ -36,9 +41,14 @@ the necessary modules for a West based [Zephyr workspace application][1].
 
 ```yaml
 - name: Checkout
-  uses: actions/checkout@v3
+  uses: actions/checkout@v4
   with:
     path: app
+
+- name: Set up Python
+  uses: actions/setup-python@v5
+  with:
+    python-version: 3.12
 
 - name: Setup Zephyr project
   uses: zephyrproject-rtos/action-zephyr-setup@v1


### PR DESCRIPTION
This follows [this comment](https://github.com/zephyrproject-rtos/action-zephyr-setup/issues/37#issuecomment-2967065860)

`actions/setup-python` must be present at least for Mac.