### PR TITLE
disable man-db update for speed increase

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,7 @@ runs:
         fi
 
         if [ "${{ runner.os }}" = "Linux" ]; then
+          sudo rm -f /var/lib/man-db/auto-update
           sudo apt-get update -y
           sudo apt-get install -y ninja-build ccache gperf
           if [ "${{ runner.arch }}" = "X64" ]; then


### PR DESCRIPTION
`running triggers for man-db` took a lot of time while installing apt packages, even though it is completely useless in ci.

For me it went from 2:17 to 1:53, so a 24 second save, which seems significant. And since this is run so often, it will also same some CO2 emissions :)