### PR TITLE
action: use $HOME/zephyr-sdk for the Zephyr SDK

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -204,11 +204,11 @@ runs:
       id: cache-toolchain
       uses: actions/cache@v4
       with:
-        path: ${{ inputs.base-path }}/zephyr-sdk
+        path: /opt/zephyr-sdk
         key: ${{ env.SDK_FILE }}-${{ inputs.toolchains }}
 
     - if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
-      working-directory: ${{ inputs.base-path }}
+      working-directory: /opt
       name: Download Zephyr SDK
       shell: bash
       run: |
@@ -222,7 +222,7 @@ runs:
         fi
 
     - name: Setup Zephyr SDK
-      working-directory: ${{ inputs.base-path }}/zephyr-sdk
+      working-directory: /opt/zephyr-sdk
       shell: bash
       run: |
         IFS=":"


### PR DESCRIPTION
The Zephyr SDK install has a step where it tweaks the library paths of the host utilities so match the full install path and have them run without having to set LD_LIBRARY_PATH. In the current setup that path includes the repository name, which means that if the repository is renamed the cached SDK is going to end up having a non working path leading to a confusing error, typically dtc not found.

Move the SDK install to the home directory, so that the path does not depend on the repository name. The SDK is found using a CMake package so it can really be installed anywhere.