### PR TITLE
test: generate the test set dynamically

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,12 +9,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Generate dynamic matrix data
+        id: set-matrix
+        run: |
+          OS='"ubuntu-24.04", "ubuntu-24.04-arm", "macos-13", "macos-14", "macos-15", "windows-2022"'
+          RELEASE='"v3.7.0", "main"'
+
+          last_releases=$( git ls-remote --tags https://github.com/zephyrproject-rtos/zephyr.git 'v*' | grep -E 'refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$' | cut -d/ -f3 | tail -n2 )
+          for r in $last_releases; do
+              RELEASE="$RELEASE, \"$r\""
+          done
+
+          MATRIX_JSON="{\"os\": [$OS], \"release\": [$RELEASE]}"
+          echo $MATRIX_JSON
+
+          echo "matrix=$MATRIX_JSON" >> $GITHUB_OUTPUT
+
   build:
+    needs: generate-matrix
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-14, macos-15, windows-2022]
-        release: [v3.7.0, v4.1.0, v4.2.0, main]
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Generate the test matrix using the last two stable tags automatically, this way we only have to update the LTS list manually.