### PR TITLE
action: clean zephyr-sdk directory before extraction

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -213,6 +213,7 @@ runs:
       shell: bash
       run: |
         wget --progress=dot:giga ${{ inputs.sdk-base }}/v${SDK_VERSION}/${SDK_FILE}
+        rm -rf zephyr-sdk
         if [ "${{ runner.os }}" = "Windows" ]; then
           7z x $SDK_FILE
           mv zephyr-sdk-${SDK_VERSION} zephyr-sdk
@@ -220,6 +221,7 @@ runs:
           mkdir zephyr-sdk
           tar xvf $SDK_FILE -C zephyr-sdk --strip-components=1
         fi
+        rm -f $SDK_FILE
 
     - name: Setup Zephyr SDK
       working-directory: ${{ inputs.base-path }}/zephyr-sdk


### PR DESCRIPTION
Remove existing zephyr-sdk directory before extraction, which is useful for self-hosted runners on which the directory remains between executions.

Important note: I'm not sure about Windows runners, I guess the same problem exists, I have added the rm command for all hosts platforms but it is tested only on Linux. If somebody can comment/test on Windows it's appreciated.