### PR TITLE
action: do not re-install ninja

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -96,12 +96,12 @@ runs:
         if [ "${{ runner.os }}" = "Linux" ]; then
           sudo rm -f /var/lib/man-db/auto-update
           sudo apt-get update -y
-          sudo apt-get install -y ninja-build ccache gperf
+          sudo apt-get install -y ccache gperf
           if [ "${{ runner.arch }}" = "X64" ]; then
             sudo apt-get install -y libc6-dev-i386 g++-multilib
           fi
         elif [ "${{ runner.os }}" = "macOS" ]; then
-          brew install ninja ccache qemu dtc gperf
+          brew install ccache qemu dtc gperf
         elif [ "${{ runner.os }}" = "Windows" ]; then
           choco feature enable -n allowGlobalConfirmation
           choco install ninja wget gperf


### PR DESCRIPTION
After many years asking, Github runners finally got ninja by default in April 2025:
- https://github.com/actions/runner-images/issues/11235

So, stop re-installing ninja - at least not unless there is a specific and documented reason to do so. This saves a little bit of time and fixes the following warning in hello_world_multiplatform.yaml:

https://github.com/zephyrproject-rtos/zephyr/actions/runs/19853412716
```
build (macos-14)
ninja 1.13.2 is already installed and up-to-date.
To reinstall 1.13.2, run: brew reinstall ninja
```

Do not change the Windows build yet because the build environment is always much more complicated on Windows, so let's first make sure this is fine on Linux and macOS.

---------


EDIT: deployed on January 14th by https://github.com/zephyrproject-rtos/zephyr/commit/a10d932c17d5c25ea7164479f468346766f9ee57 and warning is gone, for instance:
https://github.com/zephyrproject-rtos/zephyr/actions/runs/21026503446/job/60455788742  
(https://github.com/zephyrproject-rtos/zephyr/pull/102277/checks)