### PR TITLE
action: drop "choco install ninja", already installed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -104,7 +104,7 @@ runs:
           brew install ccache qemu dtc gperf coreutils
         elif [ "${{ runner.os }}" = "Windows" ]; then
           choco feature enable -n allowGlobalConfirmation
-          choco install ninja wget gperf --no-progress
+          choco install wget gperf --no-progress
         fi
 
     - name: Initialize


### PR DESCRIPTION
2 commits. Main one:

action: drop "choco install ninja", already installed

After many years asking, Github runners finally got ninja by
default in April 2025:
 - https://github.com/actions/runner-images/issues/11235

ninja was dropped from "apt-get install" and "brew install" in commit
https://github.com/zephyrproject-rtos/action-zephyr-setup/commit/9f6c54d6a349667cf6b382674580990984403823 to fix a warning on macOS. This was deployed in
https://github.com/zephyrproject-rtos/zephyr/commit/a10d932c17d5c25ea
and has not caused any issue.

But removal on Windows was delayed because building on Windows is always
more complicated, examples:
- https://github.com/thesofproject/sof/issues/8250
- https://github.com/actions/runner-images/issues/8343

Now that we know this (non-)removal has not caused any issue on Linux
and macOS, make the Windows build consistent with the others again.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>