### PR TITLE
add dependabot configuration for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Add dependabot configuration file to automate dependency updates for GitHub Actions on a weekly schedule.