### PR TITLE
github: workflows: test: tweak the test config

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,12 +60,12 @@ jobs:
             PLATFORMS_FLAGS+="-p native_sim "
           fi
           PLATFORMS_FLAGS+="-p qemu_cortex_m0 "
-          PLATFORMS_FLAGS+="-p qemu_cortex_r5 "
           PLATFORMS_FLAGS+="-p qemu_riscv32 "
-          PLATFORMS_FLAGS+="-p qemu_riscv32e "
           PLATFORMS_FLAGS+="-p qemu_riscv64 "
           PLATFORMS_FLAGS+="-p qemu_x86 "
           PLATFORMS_FLAGS+="-p qemu_x86_64"
+
+          export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 
           ./scripts/twister --force-color --inline-logs -T samples/hello_world -v $PLATFORMS_FLAGS $EXTRA_TWISTER_FLAGS
 


### PR DESCRIPTION
Drop the qemu_cortex_r5 and qemu_riscv32e platforms, these seems to be unreliable on Windows, also set ZEPHYR_TOOLCHAIN_VARIANT manually as that seems flaky on Windows as well. No point blocking action updates
because of flakyness in the platform if these are not caught in the main repository workflow so let's work on that front instead.
