### PR TITLE
Add libusb-1.0-0-dev and fix fallback pip path for Zephyr 4.4+

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -96,7 +96,7 @@ runs:
         if [ "${{ runner.os }}" = "Linux" ]; then
           sudo rm -f /var/lib/man-db/auto-update
           sudo apt-get update -y
-          sudo apt-get install -y ccache gperf
+          sudo apt-get install -y ccache gperf libusb-1.0-0-dev
           if [ "${{ runner.arch }}" = "X64" ]; then
             sudo apt-get install -y libc6-dev-i386 g++-multilib
           fi
@@ -203,7 +203,14 @@ runs:
       # The direct use of pip3 should be removed after zephyr 3.7 has been phased out, and the west
       # command should only be used instead.
       run: |
-        west packages pip --install --ignore-venv-check || pip3 install -r zephyr/scripts/requirements.txt
+        west packages pip --install --ignore-venv-check || { \
+          if [ -f zephyr/scripts/requirements.txt ]; then \
+            pip3 install -r zephyr/scripts/requirements.txt; \
+          else \
+            pip3 install -r zephyr/scripts/requirements-base.txt \
+                         -r zephyr/scripts/requirements-run-test.txt; \
+          fi; \
+        }
 
     - name: Install Python packages (Windows)
       if: runner.os == 'Windows'
@@ -212,7 +219,14 @@ runs:
       # The direct use of pip3 should be removed after zephyr 3.7 has been phased out, and the west
       # command should only be used instead.
       run: |
-        pip3 install @((west packages pip) -split ' '); if (!$?) { pip3 install -r zephyr/scripts/requirements.txt }
+        pip3 install @((west packages pip) -split ' '); if (!$?) { \
+          if (Test-Path zephyr/scripts/requirements.txt) { \
+            pip3 install -r zephyr/scripts/requirements.txt; \
+          } else { \
+            pip3 install -r zephyr/scripts/requirements-base.txt `
+                         -r zephyr/scripts/requirements-run-test.txt; \
+          } \
+        }
 
     - name: Cache Zephyr SDK
       id: cache-toolchain


### PR DESCRIPTION
The action fails on stock `ubuntu-latest` runners when building Zephyr 4.4+ projects that depend on `pyocd` (e.g. ESP32 targets). Two issues:

1. `libusb-1.0-0-dev` is missing from the Linux apt install step — `hidapi` (transitive dep of `pyocd`) fails to build from source, causing `west packages pip --install` to exit non-zero.
2. The fallback `pip3 install -r zephyr/scripts/requirements.txt` fails because Zephyr 4.4+ no longer ships a single `requirements.txt` — it was split into `requirements-base.txt`, `requirements-run-test.txt`, etc. Zephyr 3.7 LTS still has the single file, so the fallback checks for its existence first.

**Changes:**
- Add `libusb-1.0-0-dev` to the Linux install-deps step so `west packages pip` succeeds when `pyocd`/`hidapi` is pulled in.
- Make the fallback check if `zephyr/scripts/requirements.txt` exists before running it. If not, install from the split files.
- Same fix applied to the Windows PowerShell variant.
