### PR TITLE
github: workflows: test: build only on windows, test on cm3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,7 @@ jobs:
           if [ "${{ runner.os }}" = "macOS" ]; then
             EXTRA_TWISTER_FLAGS="-P native_sim --build-only"
           elif [ "${{ runner.os }}" = "Windows" ]; then
-            EXTRA_TWISTER_FLAGS="-P native_sim --short-build-path -O/tmp/twister-out"
+            EXTRA_TWISTER_FLAGS="-P native_sim --build-only --short-build-path -O/tmp/twister-out"
           fi
 
           PLATFORMS_FLAGS=""
@@ -59,7 +59,7 @@ jobs:
           else
             PLATFORMS_FLAGS+="-p native_sim "
           fi
-          PLATFORMS_FLAGS+="-p qemu_cortex_m0 "
+          PLATFORMS_FLAGS+="-p qemu_cortex_m3 "
           PLATFORMS_FLAGS+="-p qemu_riscv32 "
           PLATFORMS_FLAGS+="-p qemu_riscv64 "
           PLATFORMS_FLAGS+="-p qemu_x86 "


### PR DESCRIPTION
As of recent discussion it seems like qemu on windows is unreliable run those tests as build only and test on qemu_cortex_m3 which should be more reliable overall.

Link: https://github.com/zephyrproject-rtos/zephyr/pull/113543#pullrequestreview-4739248986